### PR TITLE
Use of @Primary on one of the implementations of Engine class to avoid the confusion

### DIFF
--- a/rest/src/main/java/com/restdemo/rest/spring_demo/BMW.java
+++ b/rest/src/main/java/com/restdemo/rest/spring_demo/BMW.java
@@ -6,11 +6,12 @@ import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 
 @Component
-@Qualifier("BMW")
+@Primary
 public class BMW implements Engine{
 
     @Override
     public String display() {
         return "BMW Engine";
     }
+    //mark @Primary at the class level
 }

--- a/rest/src/main/java/com/restdemo/rest/spring_demo/Car.java
+++ b/rest/src/main/java/com/restdemo/rest/spring_demo/Car.java
@@ -8,13 +8,12 @@ import org.springframework.stereotype.Component;
 
 public class Car {
     @Autowired
-    @Qualifier("BMW")
     private Engine engine;
 
     //BMW's display is autowired
 
-    //if you do not add qualifier here, the complier will not understand which implementation
-    // to pick for BMW and Audi as both of them have implemented engine's display method
+    //BMW's display will get picked through @Primary
+    //no need to add anything here as in the case of qualifier
 
 
 }


### PR DESCRIPTION
Just Add @Primary in the class level to which you want to consider the default implementation.